### PR TITLE
Use golang time.Duration for ttl instead of seconds

### DIFF
--- a/cmd/memcached-cli/commands.go
+++ b/cmd/memcached-cli/commands.go
@@ -207,7 +207,7 @@ func newKVGetCommand() *cobra.Command {
 
 // 修改 KV 命令，添加历史记录
 func newKVSetCommand() *cobra.Command {
-	var expiration uint32
+	var expiration time.Duration
 
 	cmd := &cobra.Command{
 		Use:          "set [key] [value]",
@@ -234,7 +234,7 @@ func newKVSetCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Uint32VarP(&expiration, "ttl", "t", 0, "ttl of key in seconds")
+	cmd.Flags().DurationVarP(&expiration, "ttl", "t", 0, "ttl of key in seconds")
 	return cmd
 }
 
@@ -329,7 +329,7 @@ func newKVTouchCommand() *cobra.Command {
 				return err
 			}
 
-			if err := client.Touch(cmd.Context(), args[0], uint32(expiration.Seconds())); err != nil {
+			if err := client.Touch(cmd.Context(), args[0], expiration); err != nil {
 				return ignoreMemcachedError(err)
 			}
 

--- a/cmd/memcached-cli/repl.go
+++ b/cmd/memcached-cli/repl.go
@@ -185,10 +185,10 @@ func (r *replCommander) handleSet(ctx context.Context, args []string) error {
 		return fmt.Errorf("usage: set <key> <value> [expiration]")
 	}
 
-	expiration := uint32(0)
+	var expiration time.Duration
 	if len(args) == 4 {
 		if e, err := strconv.ParseUint(args[2], 10, 32); err == nil {
-			expiration = uint32(e)
+			expiration = time.Duration(e) * time.Second
 		}
 	}
 
@@ -258,7 +258,7 @@ func (r *replCommander) handleTouch(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid expiration format: %v", err)
 	}
-	if err := r.getMemcachedClient().Touch(ctx, args[1], uint32(expiration)); err != nil {
+	if err := r.getMemcachedClient().Touch(ctx, args[1], time.Duration(expiration)*time.Second); err != nil {
 		return ignoreMemcachedError(err)
 	}
 	fmt.Println("OK")

--- a/example/SASL/main.go
+++ b/example/SASL/main.go
@@ -25,7 +25,7 @@ func main() {
 	}
 	println("Version: ", version)
 
-	if err = client.Set(ctx, "key", []byte("value"), 123, 5); err != nil {
+	if err = client.Set(ctx, "key", []byte("value"), 123, 5*time.Second); err != nil {
 		panic(err)
 	}
 }

--- a/example/cas.go
+++ b/example/cas.go
@@ -21,7 +21,7 @@ func main() {
 	key := "example:cas"
 
 	// first set
-	err = client.Set(ctx, key, []byte("value2"), 123, 10)
+	err = client.Set(ctx, key, []byte("value2"), 123, 10*time.Second)
 	if err != nil {
 		panic(err)
 	}
@@ -34,13 +34,13 @@ func main() {
 	fmt.Printf("before cas, key: %s, value: %+v\n", item.Key, item)
 
 	// cas
-	err = client.Cas(ctx, key, []byte("value2"), 123, 10, item.CAS)
+	err = client.Cas(ctx, key, []byte("value2"), 123, 10*time.Second, item.CAS)
 	if err != nil {
 		panic(err)
 	}
 
 	// cas again, this should fail:
-	err = client.Cas(ctx, key, []byte("value3"), 123, 10, item.CAS)
+	err = client.Cas(ctx, key, []byte("value3"), 123, 10*time.Second, item.CAS)
 	if err != nil {
 		fmt.Printf("cas failed: %v\n", err)
 	}

--- a/example/cocurrent.go
+++ b/example/cocurrent.go
@@ -33,7 +33,7 @@ func main() {
 			for counter := 0; counter < limits; counter++ {
 				key := "example:cas"
 				// set
-				err = client.Set(ctx, key, []byte("value2"), 123, 10)
+				err = client.Set(ctx, key, []byte("value2"), 123, 10*time.Second)
 				if err != nil {
 					panic("write: " + err.Error())
 				}

--- a/example/udp.go
+++ b/example/udp.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	// set
-	if err = client.Set(ctx, key, []byte(value), 0, 100); err != nil {
+	if err = client.Set(ctx, key, []byte(value), 0, 100*time.Second); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
Closes #13 

I could not test this pull request myself because I don't have the proper setup
These changes are **breaking changes**, expiring values from the previous version will be interpreted as nanoseconds
No expiry can still be expressed as `0`