### PR TITLE
Better support for Dragonfly memcache facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ func main() {
 		panic(err)
 	}
 
-	items, err := client.Gets(ctx, "key", "key2")
-	if err != nil {
-		panic(err)
-	}
+   // If you'd like to get the CAS value for each item, set withCas to true
+   items, err := client.Gets(ctx, false, "key", "key2")
+   if err != nil {
+      panic(err)
+   }
 
-	for _, item := range items {
-		println("key: ", item.Key, " value: ", string(item.Value))
-	}
+   for _, item := range items {
+      println("key: ", item.Key, " value: ", string(item.Value))
+   }
 }
 ```
 
@@ -90,33 +91,33 @@ func main() {
 
 Now, we have implemented some commands, and we will implement more commands in the future.
 
-| Command        | Status | API Usage                                                                                                           | Description                                                       |
-|----------------|--------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
-| ----           | -----  | STORAGE COMMANDS                                                                                                    | ---                                                               |
-| Set            | ✅      | `Set(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                      | Set a key-value pair to memcached                                 |
-| Add            | ✅      | `Add(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                      | Add a key-value pair to memcached                                 |
-| Replace        | ✅      | `Replace(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                  | Replace a key-value pair to memcached                             |
-| Append         | ✅      | `Append(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                   | Append a value to the key                                         |
-| Prepend        | ✅      | `Prepend(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                  | Prepend a value to the key                                        |
-| Cas            | ✅      | `Cas(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration, cas uint64) error`          | Compare and set a key-value pair to memcached                     |
-| ----           | -----  | RETRIEVAL COMMANDS                                                                                                  | ---                                                               |
-| Gets           | ✅      | `Gets(ctx context.Context, keys ...string) ([]*Item, error)`                                                        | Get a value by key from memcached with cas value                  |
-| Get            | ✅      | `Get(ctx context.Context, key string) (*Item, error)`                                                               | Get a value by key from memcached                                 |
-| GetAndTouch    | ✅      | `GetAndTouch(ctx context.Context, expiry uint32, key string) (*Item, error)`                                        | Get a value by key from memcached and touch the key's expire time |
-| GetAndTouches  | ✅      | `GetAndTouches(ctx context.Context, expiry uint32, keys ...string) ([]*Item, error)`                                | Get a value by key from memcached and touch the key's expire time |
-| -----          | -----  | OTHER COMMANDS                                                                                                      | ---                                                               |
-| Delete         | ✅      | `Delete(ctx context.Context, key string) error`                                                                     | Delete a key-value pair from memcached                            |
-| Incr           | ✅      | `Incr(ctx context.Context, key string, delta uint64) (uint64, error)`                                               | Increment a key's value                                           |
-| Decr           | ✅      | `Decr(ctx context.Context, key string, delta uint64) (uint64, error)`                                               | Decrement a key's value                                           |
-| Touch          | ✅      | `Touch(ctx context.Context, key string, expiry uint32) error`                                                       | Touch a key's expire time                                         |
-| MetaGet        | ✅      | `MetaGet(ctx context.Context, key []byte, options ...MetaGetOption) (*MetaItem, error)`                             | Get a key's meta information                                      |
-| MetaSet        | ✅      | `MetaSet(ctx context.Context, key, value []byte, options ...MetaSetOption) (*MetaItem, error)`                      | Set a key's meta information                                      |
-| MetaDelete     | ✅      | `MetaDelete(ctx context.Context, key []byte, options ...MetaDeleteOption) (*MetaItem, error)`                       | Delete a key's meta information                                   |
-| MetaArithmetic | ✅      | `MetaArithmetic(ctx context.Context, key []byte, delta uint64, options ...MetaArithmeticOption) (*MetaItem, error)` | Arithmetic a key's meta information                               |
-| MetaDebug      | ✅      | `MetaDebug(ctx context.Context, key []byte, options ...MetaDebugOption) (*MetaItemDebug, error)`                    | Debug a key's meta information                                    |
-| MetaNoop       | ✅      | `MetaNoop(ctx context.Context) error`                                                                               | Noop a key's meta information                                     |
-| Version        | ✅      | `Version(ctx context.Context) (string, error)`                                                                      | Get memcached server version                                      |
-| FlushAll       | ✅      | `FlushAll(ctx context.Context) error`                                                                               | Flush all keys in memcached server                                |
+| Command        | Status | API Usage                                                                                                           | Description                                                                                 |
+|----------------|--------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| ----           | -----  | STORAGE COMMANDS                                                                                                    | ---                                                                                         |
+| Set            | ✅      | `Set(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                      | Set a key-value pair to memcached                                                           |
+| Add            | ✅      | `Add(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                      | Add a key-value pair to memcached                                                           |
+| Replace        | ✅      | `Replace(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                  | Replace a key-value pair to memcached                                                       |
+| Append         | ✅      | `Append(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                   | Append a value to the key                                                                   |
+| Prepend        | ✅      | `Prepend(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error`                  | Prepend a value to the key                                                                  |
+| Cas            | ✅      | `Cas(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration, cas uint64) error`          | Compare and set a key-value pair to memcached                                               |
+| ----           | -----  | RETRIEVAL COMMANDS                                                                                                  | ---                                                                                         |
+| Get            | ✅      | `Get(ctx context.Context, key string) (*Item, error)`                                                               | Get a value by key from memcached                                                           |
+| Gets           | ✅      | `Gets(ctx context.Context, withCas bool, keys ...string) ([]*Item, error)`                                          | Get values by keys from memcached with an optional cas value                                |
+| GetAndTouch    | ✅      | `GetAndTouch(ctx context.Context, expiry uint32, key string) (*Item, error)`                                        | Get a value by key from memcached and touch the key's expire time                           |
+| GetAndTouches  | ✅      | `GetAndTouches(ctx context.Context, expiry uint32, keys ...string) ([]*Item, error)`                                | Get value by keys from memcached and touch the key's expire time with an optional cas value |
+| -----          | -----  | OTHER COMMANDS                                                                                                      | ---                                                                                         |
+| Delete         | ✅      | `Delete(ctx context.Context, key string) error`                                                                     | Delete a key-value pair from memcached                                                      |
+| Incr           | ✅      | `Incr(ctx context.Context, key string, delta uint64) (uint64, error)`                                               | Increment a key's value                                                                     |
+| Decr           | ✅      | `Decr(ctx context.Context, key string, delta uint64) (uint64, error)`                                               | Decrement a key's value                                                                     |
+| Touch          | ✅      | `Touch(ctx context.Context, key string, expiry uint32) error`                                                       | Touch a key's expire time                                                                   |
+| MetaGet        | ✅      | `MetaGet(ctx context.Context, key []byte, options ...MetaGetOption) (*MetaItem, error)`                             | Get a key's meta information                                                                |
+| MetaSet        | ✅      | `MetaSet(ctx context.Context, key, value []byte, options ...MetaSetOption) (*MetaItem, error)`                      | Set a key's meta information                                                                |
+| MetaDelete     | ✅      | `MetaDelete(ctx context.Context, key []byte, options ...MetaDeleteOption) (*MetaItem, error)`                       | Delete a key's meta information                                                             |
+| MetaArithmetic | ✅      | `MetaArithmetic(ctx context.Context, key []byte, delta uint64, options ...MetaArithmeticOption) (*MetaItem, error)` | Arithmetic a key's meta information                                                         |
+| MetaDebug      | ✅      | `MetaDebug(ctx context.Context, key []byte, options ...MetaDebugOption) (*MetaItemDebug, error)`                    | Debug a key's meta information                                                              |
+| MetaNoop       | ✅      | `MetaNoop(ctx context.Context) error`                                                                               | Noop a key's meta information                                                               |
+| Version        | ✅      | `Version(ctx context.Context) (string, error)`                                                                      | Get memcached server version                                                                |
+| FlushAll       | ✅      | `FlushAll(ctx context.Context) error`                                                                               | Flush all keys in memcached server                                                          |
 
 ### Development Guide
 

--- a/client_commands.go
+++ b/client_commands.go
@@ -10,29 +10,33 @@ import (
 
 type basicTextProtocolCommander interface {
 	/**
-	Storage commands: set, add, replace, append, prepend, cas
-	*/
+	 * Storage commands: set, add, replace, append, prepend, cas
+	 */
 
 	// Set is used to store the given key-value pair.
 	//
 	// flags is an arbitrary 32-bit unsigned integer (written out in decimal) that
 	// the server stores along with the data and sends back when the item is retrieved.
 	Set(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error
+
 	// Add is used to store the given key-value pair if the key does not exist.
 	//
 	// flags is an arbitrary 32-bit unsigned integer (written out in decimal) that
 	// the server stores along with the data and sends back when the item is retrieved.
 	Add(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error
+
 	// Replace is used to update the value of an existing item.
 	//
 	// flags is an arbitrary 32-bit unsigned integer (written out in decimal) that
 	// the server stores along with the data and sends back when the item is retrieved.
 	Replace(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error
+
 	// Append is used to append the value to an existing item.
 	//
 	// flags is an arbitrary 32-bit unsigned integer (written out in decimal) that
 	// the server stores along with the data and sends back when the item is retrieved.
 	Append(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration) error
+
 	// Prepend is used to prepend the value to an existing item.
 	//
 	// flags is an arbitrary 32-bit unsigned integer (written out in decimal) that
@@ -46,13 +50,14 @@ type basicTextProtocolCommander interface {
 	Cas(ctx context.Context, key string, value []byte, flags uint32, expiry time.Duration, cas uint64) error
 
 	/**
-	Retrieval commands: get and gets
-	*/
+	 * Retrieval commands: get, gets, gat, gats
+	 */
 
 	// Get gets the value of the given key.
 	//
 	// This command would not return the <cas unique> value, using `Gets` instead.
 	Get(ctx context.Context, key string) (*Item, error)
+
 	// Gets the values of the given keys.
 	//
 	// BUT you must know that the cluster mode of memcached DOES NOT support this command,
@@ -60,29 +65,35 @@ type basicTextProtocolCommander interface {
 	// Be careful when using this command unless you are sure that
 	// all keys are stored in the same memcached instance.
 	//
-	// Gets will return the <cas unique> value which is used to check-and-set operation.
-	Gets(ctx context.Context, keys ...string) ([]*Item, error)
+	// Gets will return the <cas unique> value which is used to check-and-set operation if withCas is true.
+	Gets(ctx context.Context, withCas bool, keys ...string) ([]*Item, error)
+
 	// GetAndTouch is used to get the value of the given key and update the expiration time of the key.
 	GetAndTouch(ctx context.Context, expiry time.Duration, key string) (*Item, error)
+
 	// GetAndTouches is used to get the values of the given keys and update the expiration time of the keys.
 	//
 	// BUT you must know that the cluster mode of memcached DOES NOT support this command,
 	// since keys are possible stored in different memcached instances.
 	// Be careful when using this command unless you are sure that
 	// all keys are stored in the same memcached instance.
-	GetAndTouches(ctx context.Context, expiry time.Duration, keys ...string) ([]*Item, error)
+	GetAndTouches(ctx context.Context, expiry time.Duration, withCas bool, keys ...string) ([]*Item, error)
+
 	/**
-	Other commands: delete
-	*/
+	 * Other commands: delete, incr, decr, touch, version, flush_all
+	 */
 
 	// Delete is used to delete the given key.
 	Delete(ctx context.Context, key string) error
+
 	// Incr is used to increment the value of the given key.
 	// If noReply mode enabled, it will return 0.
 	Incr(ctx context.Context, key string, delta uint64) (uint64, error)
+
 	// Decr is used to decrement the value of the given key.
 	// If noReply mode enabled, it will return 0.
 	Decr(ctx context.Context, key string, delta uint64) (uint64, error)
+
 	// Touch is used to update the expiration time of an existing item
 	// without fetching it.
 	Touch(ctx context.Context, key string, expiry time.Duration) error
@@ -103,21 +114,26 @@ type metaTextProtocolCommander interface {
 	// All available options start with MetaSetFlagXXX, such as MetaSetFlagBinaryKey
 	// and MetaSetFlagReturnCAS.
 	MetaSet(ctx context.Context, key, value []byte, options ...MetaSetOption) (*MetaItem, error)
+
 	// MetaGet is used to get the value of the given key with metadata.
 	// All available options start with MetaGetFlagXXX, such as MetaGetFlagReturnCAS
 	// and MetaGetFlagReturnClientFlags.
 	MetaGet(ctx context.Context, key []byte, options ...MetaGetOption) (*MetaItem, error)
+
 	// MetaDelete is used to delete the given key with metadata.
 	// All available options start with MetaDeleteFlagXXX, such as MetaDeleteFlagRemoveValueOnly
 	// and MetaDeleteFlagUpdateTTL.
 	MetaDelete(ctx context.Context, key []byte, options ...MetaDeleteOption) (*MetaItem, error)
+
 	// MetaArithmetic is used to increment or decrement the value of the given key with metadata.
 	// All available options start with MetaArithmeticFlagXXX, such as MetaArithmeticFlagReturnCAS
 	// and MetaArithmeticFlagReturnClientFlags.
 	MetaArithmetic(ctx context.Context, key []byte, delta uint64, options ...MetaArithmeticOption) (*MetaItem, error)
+
 	// MetaDebug is used to get the debug information of the given key with metadata.
 	// All available options start with MetaDebugFlagXXX, such as MetaDebugFlagBinaryKey
 	MetaDebug(ctx context.Context, key []byte, options ...MetaDebugOption) (*MetaItemDebug, error)
+
 	// MetaNoOp is used to do nothing but return OK.
 	MetaNoOp(ctx context.Context) error
 }
@@ -220,12 +236,19 @@ func (c *client) Get(ctx context.Context, key string) (*Item, error) {
 	return items[0], nil
 }
 
-func (c *client) Gets(ctx context.Context, keys ...string) ([]*Item, error) {
+func (c *client) Gets(ctx context.Context, withCas bool, keys ...string) ([]*Item, error) {
 	if len(keys) == 0 {
 		return []*Item{}, nil
 	}
 
-	req, resp := buildGetsCommand("gets", keys...)
+	var command string
+	if withCas {
+		command = "gets"
+	} else {
+		command = "get"
+	}
+
+	req, resp := buildGetsCommand(command, keys...)
 	defer releaseReqAndResp(req, resp)
 
 	if err := c.dispatchRequest(ctx, req, resp); err != nil {
@@ -233,7 +256,7 @@ func (c *client) Gets(ctx context.Context, keys ...string) ([]*Item, error) {
 	}
 
 	// parse response
-	items, err := parseValueItems(resp.rawLines, false, true)
+	items, err := parseValueItems(resp.rawLines, false, withCas)
 	if err != nil {
 		return nil, errors.Wrap(ErrMalformedResponse, "parse values failed")
 	}
@@ -269,12 +292,19 @@ func (c *client) GetAndTouch(ctx context.Context, expiry time.Duration, key stri
 	return items[0], nil
 }
 
-func (c *client) GetAndTouches(ctx context.Context, expiry time.Duration, keys ...string) ([]*Item, error) {
+func (c *client) GetAndTouches(ctx context.Context, expiry time.Duration, withCas bool, keys ...string) ([]*Item, error) {
 	if len(keys) == 0 {
 		return []*Item{}, nil
 	}
 
-	req, resp := buildGetAndTouchesCommand("gats", expiry, keys...)
+	var command string
+	if withCas {
+		command = "gets"
+	} else {
+		command = "get"
+	}
+
+	req, resp := buildGetAndTouchesCommand(command, expiry, keys...)
 	defer releaseReqAndResp(req, resp)
 
 	if err := c.dispatchRequest(ctx, req, resp); err != nil {
@@ -282,7 +312,7 @@ func (c *client) GetAndTouches(ctx context.Context, expiry time.Duration, keys .
 	}
 
 	// parse response
-	items, err := parseValueItems(resp.rawLines, false, true)
+	items, err := parseValueItems(resp.rawLines, false, withCas)
 	if err != nil {
 		return nil, errors.Wrap(ErrMalformedResponse, "parse values failed")
 	}

--- a/example/cas.go
+++ b/example/cas.go
@@ -26,7 +26,7 @@ func main() {
 		panic(err)
 	}
 	// gets
-	items, err := client.Gets(ctx, key)
+	items, err := client.Gets(ctx, true, key)
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	// get again
-	items, err = client.Gets(ctx, key)
+	items, err = client.Gets(ctx, true, key)
 	if err != nil {
 		panic(err)
 	}

--- a/example/simple.go
+++ b/example/simple.go
@@ -43,7 +43,7 @@ func main() {
 		panic(err)
 	}
 
-	items, err := client.Gets(ctx, "key", "key2")
+	items, err := client.Gets(ctx, false, "key", "key2")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I've bumped into issues when attempting to use gets and gats with a memcache compatible facade for [DragonFly](https://github.com/dragonflydb/dragonfly)

They did not fully implement the basic text protocol have in some cases changed the behavior of some commands
After further researching, I've found that the `get` and `gat` commands can return more than just one key and decided to add a simple condition in `Gets` and `GetsAndTouch` to specify whether the user wants to use CAS commands

I've made sure that this change would not break existing codebases but more testing would be great

https://docs.memcached.org/protocols/basic/#get